### PR TITLE
Add missing switch back to master branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ In the diagram below you see how our commit history now looks. Both _master_ and
 
 ![Divergent commits](img/branches_diverge.png)
 
-If you now `git merge change_alice` a fast-forward merge is not possible. Instead your favorite text editor will open and allow you to change the message of the `merge commit` git is about to make in order to get the two branches back together. You can just go with the default message right now. The diagram below shows the state of our git history after we the `merge`.
+If you now switch back to master (`git checkout master`) and do `git merge change_alice` a fast-forward merge is not possible. Instead your favorite text editor will open and allow you to change the message of the `merge commit` git is about to make in order to get the two branches back together. You can just go with the default message right now. The diagram below shows the state of our git history after we the `merge`.
 
 ![Merging branches](img/merge.png)
 


### PR DESCRIPTION
In the `Merging divergent branches` section it is stated to merge the
`change_alice` branch into the `change_alice` branch. This makes no
sense and the accompanying picture tells a different story. In reality
the `change_alice` branch should be merged into master. This is now
fixed.