### PR TITLE
Fix a very (very) small typo in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -933,7 +933,7 @@ So theres a record of any time you make a `commit`, but also of when you `reset`
 
 Having read this tutorial so far, you see how this might come in handy when we've messed up a `rebase` right? 
 
-We know that a `rebase` moves the `HEAD` of our branch to the point we're basing it on and the applies our changes. An interactive `rebase` works similarly, but might do things to those commits like _squashing_ or _rewording_ them. 
+We know that a `rebase` moves the `HEAD` of our branch to the point we're basing it on and then applies our changes. An interactive `rebase` works similarly, but might do things to those commits like _squashing_ or _rewording_ them. 
 
 If you're not still on the branch on which we practiced [interactive rebase](#interactive-rebase), switch to it again, as we're about to practice some more there. 
 


### PR DESCRIPTION
Hi! Humm, okay, I want to tell you this; This is the most amazing article I have read so far that tackles _Git_ layer from above. If anyone want to understand the **above** layer of _Git_, this is what I recommend reading.
If one wants to go really deep, then I guess reading this and then reading the [Pro Git](https://git-scm.com/) book is a good learning flow. You did an amazing job _Nico Riedmann_. 

This PR is reaaaaaally so small, it just fix some typo. We will fix the sentence from 

> we're basing it on and the applies our changes

to

> we're basing it on and then applies our changes


I also found another that is fixed here but not on [Dev.to](https://dev.to/unseenwizzard/learn-git-concepts-not-commands-4gjc) post, so consider editing the article too. Search for this line  

> you're perfectly save to do a 

and change _save_ to _safe_.

I guess it makes more sense now! :sparkles: